### PR TITLE
fix: change the name of ida binary

### DIFF
--- a/cmake/IDA.cmake
+++ b/cmake/IDA.cmake
@@ -80,11 +80,7 @@ elseif (UNIX)
     endif ()
 
     # On unixoid platforms, we link against IDA directly.
-    if (IDA_EA_64)
-        find_library(IDA_IDA_LIBRARY NAMES "ida64" PATHS ${IDA_INSTALL_DIR} REQUIRED)
-    else ()
-        find_library(IDA_IDA_LIBRARY NAMES "ida" PATHS ${IDA_INSTALL_DIR} REQUIRED)
-    endif ()
+    find_library(IDA_IDA_LIBRARY NAMES "ida" PATHS ${IDA_INSTALL_DIR} REQUIRED)
     list(APPEND ida_libraries ${IDA_IDA_LIBRARY})
 endif ()
 


### PR DESCRIPTION
With IDA Pro 9.x, Hex-Rays unified 32-bit and 64-bit support into a single binary. The "64" suffix used in to differentiate the endianess is no longer required for plugin but it was removed for ida's executable.