### PR TITLE
up: Qt6 tweaks

### DIFF
--- a/cmake/IDA.cmake
+++ b/cmake/IDA.cmake
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0054 NEW)
 
 # =============================================================================================== #
@@ -81,7 +81,7 @@ elseif (UNIX)
 
     # On unixoid platforms, we link against IDA directly.
     if (IDA_EA_64)
-        find_library(IDA_IDA_LIBRARY NAMES "ida64" PATHS ${IDA_INSTALL_DIR} REQUIRED)
+        find_library(IDA_IDA_LIBRARY NAMES "ida" PATHS ${IDA_INSTALL_DIR} REQUIRED)
     else ()
         find_library(IDA_IDA_LIBRARY NAMES "ida" PATHS ${IDA_INSTALL_DIR} REQUIRED)
     endif ()
@@ -231,10 +231,10 @@ function (add_ida_qt_plugin plugin_name)
     endforeach ()
 
     # Compile UI files.
-    QT5_WRAP_UI(form_headers ${ui_sources})
+    QT6_WRAP_UI(form_headers ${ui_sources})
 
     # Compile resources.
-    QT5_ADD_RESOURCES(rsrc_headers ${rsrc_sources})
+    QT6_ADD_RESOURCES(rsrc_headers ${rsrc_sources})
 
     # Add plugin.
     add_ida_plugin(${plugin_name} ${non_ui_sources} ${form_headers} ${rsrc_headers})
@@ -244,10 +244,10 @@ function (add_ida_qt_plugin plugin_name)
     foreach (qtlib Core;Gui;Widgets)
         if (DEFINED IDA_QtCore_LIBRARY)
             set_target_properties(
-                "Qt5::${qtlib}"
+                "Qt6::${qtlib}"
                 PROPERTIES 
                 IMPORTED_LOCATION_RELEASE "${IDA_Qt${qtlib}_LIBRARY}")
         endif ()
-        target_link_libraries(${plugin_name} PUBLIC "Qt5::${qtlib}")
+        target_link_libraries(${plugin_name} PUBLIC "Qt6::${qtlib}")
     endforeach()
 endfunction ()

--- a/cmake/QtIDA.cmake
+++ b/cmake/QtIDA.cmake
@@ -10,7 +10,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(ida_qt_libs "Gui;Core;Widgets")
 
 # Locate Qt.
-find_package(Qt5Widgets 5.6 REQUIRED)
+find_package(Qt6Widgets 6.8 REQUIRED)
 
 # On unixes, we link against the Qt libs that ship with IDA.
 # On Windows with IDA versions >= 7.0, link against .libs in IDA SDK.
@@ -20,9 +20,9 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Lin
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         set(ida_qt_glob_path "${IDA_INSTALL_DIR}/../Frameworks/Qt@QTLIB@")
     elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-        set(ida_qt_glob_path "${IDA_INSTALL_DIR}/libQt5@QTLIB@.so*")
+        set(ida_qt_glob_path "${IDA_INSTALL_DIR}/libQt6@QTLIB@.so*")
     elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-        set(ida_qt_glob_path "${IDA_SDK}/lib/x64_win_qt/Qt5@QTLIB@.lib")
+        set(ida_qt_glob_path "${IDA_SDK}/lib/x64_win_qt/Qt6@QTLIB@.lib")
     endif ()
 
     foreach(cur_lib ${ida_qt_libs})
@@ -45,7 +45,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Lin
 
     foreach (cur_lib ${ida_qt_libs})
         set_target_properties(
-            "Qt5::${cur_lib}"
+            "Qt6::${cur_lib}"
             PROPERTIES 
             ${lib_property} "${IDA_Qt${cur_lib}_LIBRARY}")
     endforeach()


### PR DESCRIPTION
## Changes

We need ida-cmake project to be updated for Qt6

* `Qt5` prefixes changed to `Qt6`
* Hexrays people only distributes 64bit binaries (previously there was both 32 bit and 64 bit ida binaries)
* cmake min version updated to 3.21 (Ubuntu 22 uses 3.22 as of today)